### PR TITLE
refactor(fabric-history): refactor the fabric-history and tuning the HistoryPlugin

### DIFF
--- a/packages/core/plugin/DringPlugin.ts
+++ b/packages/core/plugin/DringPlugin.ts
@@ -26,13 +26,13 @@ export class DringPlugin implements IPluginTempl {
 
   startDring() {
     this.dragMode = true;
-    this.canvas.defaultCursor = 'grab';
+    this.canvas.setCursor('grab');
     this.editor.emit('startDring');
     this.canvas.renderAll();
   }
   endDring() {
     this.dragMode = false;
-    this.canvas.defaultCursor = 'default';
+    this.canvas.setCursor('default');
     this.canvas.isDragging = false;
     this.editor.emit('endDring');
     this.canvas.renderAll();
@@ -44,7 +44,7 @@ export class DringPlugin implements IPluginTempl {
     this.canvas.on('mouse:down', function (this: ExtCanvas, opt) {
       const evt = opt.e;
       if (evt.altKey || This.dragMode) {
-        This.canvas.defaultCursor = 'grabbing';
+        This.canvas.setCursor('grabbing');
         This.canvas.discardActiveObject();
         This._setDring();
         this.selection = false;
@@ -56,9 +56,10 @@ export class DringPlugin implements IPluginTempl {
     });
 
     this.canvas.on('mouse:move', function (this: ExtCanvas, opt) {
+      This.dragMode && This.canvas.setCursor('grab');
       if (this.isDragging) {
         This.canvas.discardActiveObject();
-        This.canvas.defaultCursor = 'grabbing';
+        This.canvas.setCursor('grabbing');
         const { e } = opt;
         if (!this.viewportTransform) return;
         const vpt = this.viewportTransform;
@@ -80,14 +81,13 @@ export class DringPlugin implements IPluginTempl {
           obj.selectable = true;
         }
       });
-      This.canvas.defaultCursor = 'default';
+      This.dragMode && This.canvas.setCursor('grab');
       this.requestRenderAll();
     });
   }
 
   _setDring() {
     this.canvas.selection = false;
-    this.canvas.defaultCursor = 'grab';
     this.canvas.getObjects().forEach((obj) => {
       obj.selectable = false;
     });

--- a/packages/core/plugin/HistoryPlugin.ts
+++ b/packages/core/plugin/HistoryPlugin.ts
@@ -2,21 +2,22 @@
 /*
  * @Author: 秦少卫
  * @Date: 2023-06-20 13:06:31
- * @LastEditors: 秦少卫
- * @LastEditTime: 2024-07-12 21:35:16
+ * @LastEditors: George GeorgeSmith163@163.com
+ * @LastEditTime: 2024-10-11 11:11:11
  * @Description: 历史记录插件
  */
 import { fabric } from 'fabric';
 import Editor from '../Editor';
 import '../utils/fabric-history.js';
 
+type callback = () => void;
 type IEditor = Editor;
 type extendCanvas = {
-  undo: () => void;
-  redo: () => void;
+  undo: (callback?: callback) => void;
+  redo: (callback?: callback) => void;
   clearHistory: () => void;
-  historyUndo: any[];
-  historyRedo: any[];
+  historyStack: any[];
+  historyIndex: number;
 };
 
 class HistoryPlugin implements IPluginTempl {
@@ -36,15 +37,15 @@ class HistoryPlugin implements IPluginTempl {
       this.historyUpdate();
     });
     window.addEventListener('beforeunload', (e) => {
-      if (this.canvas.historyUndo.length > 0) {
+      if (this.canvas.historyStack.length > 0) {
         (e || window.event).returnValue = '确认离开';
       }
     });
   }
 
   historyUpdate() {
-    const { historyUndo, historyRedo } = this.canvas;
-    this.editor.emit('historyUpdate', historyUndo.length, historyRedo.length);
+    const { historyStack, historyIndex } = this.canvas;
+    this.editor.emit('historyUpdate', historyIndex, historyStack.length - historyIndex);
   }
 
   // 导入模板之后，清理 History 缓存
@@ -55,10 +56,6 @@ class HistoryPlugin implements IPluginTempl {
   }
 
   undo() {
-    // if (this.canvas.historyUndo.length === 1) {
-    //   // this.canvas.clearUndo();
-    //   // this.editor.clear();
-    // }
     this.canvas.undo();
     this.historyUpdate();
   }


### PR DESCRIPTION
## 贡献者你好
很高兴你能付出自己的时间参与到vue-fabric-editor的共享当中去，相信很多人都因为你提交的代码而收益。

### 原则
我们希望每次提交尽量小，较大重构除外，确保我们每次的改动影响范围清晰明了，能够方便项目维护者快速的将代码合并到主分支。

### 确保你的代码与主仓库没有冲突
在PR前，请确保你的代码与主仓库保持同步，可以参考这篇[文章](https://zhuanlan.zhihu.com/p/467670042)。

### 确保你的代码代码能正常打包构建
在PR前，请在本地进行打包构建，并进行功能测试，确保功能正常，且不影响其他功能。
- [x] 代码构建正常

### 告知项目维护者本次修改的功能
重构了 fabric-history.js 文件。并调整了 HistoryPlugin.ts 文件以适配新的 fabric-history。
大致实现/修复了以下功能：
1、修复了每次都要撤销两次的bug。
2、实现保存历史前先清除redo的旧记录，不然可能会redo之前某个阶段的操作记录。
3、实现保存历史数添加上限值。
4、修复历史记录恢复后，鼠标悬浮 workspace 会出现可操作样式的bug。
具体内容参看代码及注释。

