### PR TITLE
fix(右键菜单): 右键菜单显示快捷建错误问题修复

### DIFF
--- a/packages/core/plugin/CenterAlignPlugin.ts
+++ b/packages/core/plugin/CenterAlignPlugin.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: 秦少卫
  * @Date: 2023-06-15 22:49:42
- * @LastEditors: 秦少卫
- * @LastEditTime: 2024-07-09 14:12:41
+ * @LastEditors: bigFace2019 599069310@qq.com
+ * @LastEditTime: 2024-11-03 20:39:43
  * @Description: 居中对齐插件
  */
 
@@ -59,7 +59,7 @@ class CenterAlignPlugin implements IPluginTempl {
       return [
         {
           text: '水平垂直居中',
-          hotkey: 'Ctrl+V',
+          hotkey: '',
           disabled: false,
           onclick: () => this.position('center'),
         },

--- a/packages/core/plugin/DeleteHotKeyPlugin.ts
+++ b/packages/core/plugin/DeleteHotKeyPlugin.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: 秦少卫
  * @Date: 2023-06-20 12:57:35
- * @LastEditors: 秦少卫
- * @LastEditTime: 2024-04-10 17:33:02
+ * @LastEditors: bigFace2019 599069310@qq.com
+ * @LastEditTime: 2024-11-03 20:38:33
  * @Description: 删除快捷键
  */
 
@@ -42,7 +42,10 @@ class DeleteHotKeyPlugin implements IPluginTempl {
   contextMenu() {
     const activeObject = this.canvas.getActiveObject();
     if (activeObject) {
-      return [null, { text: '删除', hotkey: 'Ctrl+V', disabled: false, onclick: () => this.del() }];
+      return [
+        null,
+        { text: '删除', hotkey: 'Backspace', disabled: false, onclick: () => this.del() },
+      ];
     }
   }
 

--- a/packages/core/plugin/FlipPlugin.ts
+++ b/packages/core/plugin/FlipPlugin.ts
@@ -1,6 +1,7 @@
 import { fabric } from 'fabric';
 import { SelectMode } from '../eventType';
 import type { IEditor, IPluginTempl } from '@kuaitu/core';
+import i18n from "@/language";
 
 type IPlugin = Pick<FlipPlugin, 'flip'>;
 
@@ -9,7 +10,6 @@ declare module '@kuaitu/core' {
   interface IEditor extends IPlugin {}
 }
 
-const t = (key: string) => key;
 // import event from '@/utils/event/notifier';
 
 export default class FlipPlugin implements IPluginTempl {
@@ -34,12 +34,12 @@ export default class FlipPlugin implements IPluginTempl {
           hotkey: '❯',
           subitems: [
             {
-              text: t('flip.x'),
+              text: i18n.global.t('flip.x'),
               hotkey: '|',
               onclick: () => this.flip('X'),
             },
             {
-              text: t('flip.y'),
+              text: i18n.global.t('flip.y'),
               hotkey: '-',
               onclick: () => this.flip('Y'),
             },

--- a/src/language/zh.json
+++ b/src/language/zh.json
@@ -6,6 +6,10 @@
     "width": "宽度",
     "height": "高度"
   },
+  "flip": {
+    "x": "水平翻转",
+    "y": "垂直翻转"
+  },
   "attrSeting": {
     "group": "成组",
     "unGroup": "拆分组",


### PR DESCRIPTION
## 贡献者你好
很高兴你能付出自己的时间参与到vue-fabric-editor的共享当中去，相信很多人都因为你提交的代码而收益。

### 原则
我们希望每次提交尽量小，较大重构除外，确保我们每次的改动影响范围清晰明了，能够方便项目维护者快速的将代码合并到主分支。

### 确保你的代码与主仓库没有冲突
在PR前，请确保你的代码与主仓库保持同步，可以参考这篇[文章](https://zhuanlan.zhihu.com/p/467670042)。

### 确保你的代码代码能正常打包构建
在PR前，请在本地进行打包构建，并进行功能测试，确保功能正常，且不影响其他功能。
- [ ] 代码构建正常

### 告知项目维护者本次修改的功能
问题：右键菜单中‘删除’和’水平垂直居中‘’快捷键都是Ctr+V
![image](https://github.com/user-attachments/assets/112fbcf7-afb8-4eb5-a528-c3d98474a05e)

修改后：
![image](https://github.com/user-attachments/assets/f2095cc7-3def-4fe4-ab3a-5925b0c96b0f)


问题2：右键翻转的国际化显示错误
![image](https://github.com/user-attachments/assets/e27ffcf1-efef-426a-af39-c311034cfb3f)
修复后：
![image](https://github.com/user-attachments/assets/8951d699-8973-4439-ad05-e0fb52d1faa3)

