### PR TITLE
fix: @jridgewell/source-map@0.3.6 deps error

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,10 @@
       "eslint --fix",
       "prettier --write"
     ]
+  },
+  "pnpm": {
+    "overrides": {
+      "@jridgewell/gen-mapping": "0.3.5"
+    }
   }
 }


### PR DESCRIPTION
## 贡献者你好
很高兴你能付出自己的时间参与到vue-fabric-editor的共享当中去，相信很多人都因为你提交的代码而收益。

### 原则
我们希望每次提交尽量小，较大重构除外，确保我们每次的改动影响范围清晰明了，能够方便项目维护者快速的将代码合并到主分支。

### 确保你的代码与主仓库没有冲突
在PR前，请确保你的代码与主仓库保持同步，可以参考这篇[文章](https://zhuanlan.zhihu.com/p/467670042)。

### 确保你的代码代码能正常打包构建
在PR前，请在本地进行打包构建，并进行功能测试，确保功能正常，且不影响其他功能。
- [ x ] 代码构建正常

### 告知项目维护者本次修改的功能
写入你的修改内容。

<img width="1238" alt="image" src="https://github.com/user-attachments/assets/7f6dda70-18bf-4272-9174-0b929b76d7c4">

间接依赖 `@jridgewell/source-map@0.3.6` 存在问题

https://github.com/jridgewell/sourcemaps/issues/6



